### PR TITLE
WIP: Periodically reload configuration from remote location

### DIFF
--- a/conf/fetcher.js
+++ b/conf/fetcher.js
@@ -2,38 +2,71 @@ const https = require('https');
 const fs = require('fs');
 const configFileParser = require('../conf/parser/file');
 
-const download = function(url, dest, timeout, cb) {
+const download = function(url, dest, etagDest, timeout, cb) {
   try {
-    fs.unlink(dest, function() {
+    fs.unlink(dest, function(err) {
+      if(err && err.code != 'ENOENT') {
+        // couldn't remove the file
+        return cb(err);
+      }
+
       var file = fs.createWriteStream(dest);
-      var request = https.get(url, function(response) {
-        response.pipe(file);
-        file.on('finish', function() {
-          file.close(cb);
-        });
-      }).on('error', function(err) {
-        fs.unlink(dest);
-        cb(err);
+      file.on('error', function(err) {
+        // couldn't write to the file
+        fs.unlink(dest, function() { cb(err); });
+      }).on('finish', function() {
+        file.close(cb);
       });
 
+      var request = https.get(url, function(response) {
+        // if the contents of the config file are the same, we don't need to reload anything
+        if (response.headers && response.headers['etag']) {
+          var lastEtag;
+
+          // we do this synchronously to avoid piping anything to the file stream unless
+          // the content is new
+          try {
+            lastEtag = fs.readFileSync(etagDest, { encoding: 'utf8' });
+          } catch(e) {}
+
+          if (lastEtag == response.headers['etag']) {
+            return file.close(function() {
+              cb(null, true);
+            });
+          }
+
+          fs.writeFile(etagDest, response.headers['etag'], function(err) {
+            if (err) return cb(err);
+          });
+        }
+
+        response.pipe(file);
+      }).on('error', function(err) {
+        // couldn't download it from the URL
+        fs.unlink(dest, function() { cb(err); });
+      });
       request.setTimeout(timeout, function(err) {
-        fs.unlink(dest);
-        cb(err);
+        // timed out when trying to download it in due time
+        fs.unlink(dest, function() { cb(err); });
       });
     });
   } catch (err) {
+    // something weird happened here
     cb(err);
   }
 };
 
 module.exports.fetchRemoteConfiguration = function(config, cb) {
-  const tmpConfigPath = '/tmp/limitd-remote-config';
-  download(config.remoteConfigURI, tmpConfigPath, config.remoteConfigTimeout || 3000, function() {
+  const tmpConfigPath = config.tmpConfigPath || '/tmp/limitd-remote-config';
+  const tmpConfigEtagPath = config.tmpConfigEtagPath || `${config.tmpConfigPath}.etag`;
+  download(config.remoteConfigURI, tmpConfigPath, tmpConfigEtagPath, config.remoteConfigTimeout || 3000, function(err, configIsEquals) {
+    if (err) return cb(err);
+    if (configIsEquals) return cb();
+
     try {
       const parsedFromFile = configFileParser.parse(tmpConfigPath);
       cb(null, parsedFromFile);
     } catch (e) {
-      console.error('Error parsing configuration from remote location\n', e.stack);
       return cb(e);
     }
   })

--- a/conf/fetcher.js
+++ b/conf/fetcher.js
@@ -1,0 +1,40 @@
+const https = require('https');
+const fs = require('fs');
+const configFileParser = require('../conf/parser/file');
+
+const download = function(url, dest, timeout, cb) {
+  try {
+    fs.unlink(dest, function() {
+      var file = fs.createWriteStream(dest);
+      var request = https.get(url, function(response) {
+        response.pipe(file);
+        file.on('finish', function() {
+          file.close(cb);
+        });
+      }).on('error', function(err) {
+        fs.unlink(dest);
+        cb(err);
+      });
+
+      request.setTimeout(timeout, function(err) {
+        fs.unlink(dest);
+        cb(err);
+      });
+    });
+  } catch (err) {
+    cb(err);
+  }
+};
+
+module.exports.fetchRemoteConfiguration = function(config, cb) {
+  const tmpConfigPath = '/tmp/limitd-remote-config';
+  download(config.remoteConfigURI, tmpConfigPath, config.remoteConfigTimeout || 3000, function() {
+    try {
+      const parsedFromFile = configFileParser.parse(tmpConfigPath);
+      cb(null, parsedFromFile);
+    } catch (e) {
+      console.error('Error parsing configuration from remote location\n', e.stack);
+      return cb(e);
+    }
+  })
+};

--- a/conf/fetcher.js
+++ b/conf/fetcher.js
@@ -5,7 +5,7 @@ const configFileParser = require('../conf/parser/file');
 const download = function(url, dest, etagDest, timeout, cb) {
   try {
     fs.unlink(dest, function(err) {
-      if(err && err.code != 'ENOENT') {
+      if(err && err.code !== 'ENOENT') {
         // couldn't remove the file
         return cb(err);
       }
@@ -29,7 +29,7 @@ const download = function(url, dest, etagDest, timeout, cb) {
             lastEtag = fs.readFileSync(etagDest, { encoding: 'utf8' });
           } catch(e) {}
 
-          if (lastEtag == response.headers['etag']) {
+          if (lastEtag === response.headers['etag']) {
             return file.close(function() {
               cb(null, true);
             });
@@ -69,5 +69,5 @@ module.exports.fetchRemoteConfiguration = function(config, cb) {
     } catch (e) {
       return cb(e);
     }
-  })
+  });
 };

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "limitd-client": "^2.13.2",
     "mocha": "~5.0.4",
     "mockdate": "~2.0.2",
+    "nock": "^9.2.5",
     "progress": "~2.0.0",
     "rimraf": "~2.6.2"
   }

--- a/server.js
+++ b/server.js
@@ -63,7 +63,7 @@ function LimitdServer (options) {
 
   if (this._config.remoteConfigURI) {
     setInterval(function() {
-      logger.info({ remoteConfigURI: self._config.remoteConfigURI }, 'Trying to fetch configuration from remote location')
+      logger.info({ remoteConfigURI: self._config.remoteConfigURI }, 'Trying to fetch configuration from remote location');
       configFetcher.fetchRemoteConfiguration(self._config, function(err, config) {
         if (err) return logger.error({ err: err, remoteConfigURI: self._config.remoteConfigURI }, 'Error fetching configuration from remote location');
         if (config && config.buckets) {

--- a/test/config.fetcher.tests.js
+++ b/test/config.fetcher.tests.js
@@ -1,0 +1,96 @@
+const assert = require('chai').assert;
+const fs = require('fs');
+const nock = require('nock');
+const fetcher = require('../conf/fetcher');
+
+describe('config file fetcher', function() {
+  var config;
+  var remoteConfigFile;
+  before(function() {
+    config = null;
+    remoteConfigFile = fs.readFileSync(`${__dirname}/fixture/fixture-remote.yml`, { encoding: 'utf8' });
+  });
+
+  it('should not crash if it can\'t remove or save to the file', function() {
+    fetcher.fetchRemoteConfiguration({
+      tmpConfigPath: '/root/something-i-cant-change',
+      tmpConfigEtagPath: '/tmp/foo-bar',
+      remoteConfigURI: 'https://foo.bar/mylimit.config'
+    }, function(err) {
+      assert.exists(err);
+    });
+  });
+
+  it('should not crash if it can\'t save the file etag', function() {
+    fetcher.fetchRemoteConfiguration({
+      tmpConfigPath: '/tmp/foo-bar-baz',
+      tmpConfigEtagPath: '/root/something-i-cant-write-to',
+      remoteConfigURI: 'https://foo.bar/mylimit.config'
+    }, function(err) {
+      assert.exists(err);
+    });
+  });
+
+  it('should not change contents if the etag matches previous content', function() {
+    nock('https://foo.bar')
+      .persist()
+      .defaultReplyHeaders({
+        'etag': '123'
+      })
+      .get('/mylimit.config')
+      .reply(200, remoteConfigFile);
+
+    fs.writeFileSync('/tmp/should-not-change', remoteConfigFile, { encoding: 'utf8' })
+    fs.writeFileSync('/tmp/should-not-change.etag', '123', { encoding: 'utf8' });
+
+    fetcher.fetchRemoteConfiguration({
+      tmpConfigPath: '/tmp/should-not-change',
+      tmpConfigEtagPath: '/tmp/should-not-change.etag',
+      remoteConfigURI: 'https://foo.bar/mylimit.config'
+    }, function(err, contents) {
+      assert.notExists(err);
+      assert.notExists(contents);
+    });
+  });
+
+  it('should not crash if the downloaded file can\'t be parsed', function() {
+    nock('https://foo.bar')
+      .persist()
+      .defaultReplyHeaders({
+        'etag': '1234'
+      })
+      .get('/mylimit.invalid.config')
+      .reply(200, 'lol this is invalid');
+
+    fetcher.fetchRemoteConfiguration({
+      tmpConfigPath: '/tmp/should-change',
+      tmpConfigEtagPath: '/tmp/should-change.etag',
+      remoteConfigURI: 'https://foo.bar/mylimit.invalid.config'
+    }, function(err, contents) {
+      assert.exists(err);
+      assert.notExists(contents);
+    });
+  });
+
+  it('should save file to the destination', function() {
+    nock('https://foo.bar')
+      .persist()
+      .defaultReplyHeaders({
+        'etag': '1234'
+      })
+      .get('/mylimit.config')
+      .reply(200, remoteConfigFile);
+
+    fs.writeFileSync('/tmp/should-change', remoteConfigFile, { encoding: 'utf8' })
+    fs.writeFileSync('/tmp/should-change.etag', '1233', { encoding: 'utf8' });
+
+    fetcher.fetchRemoteConfiguration({
+      tmpConfigPath: '/tmp/should-change',
+      tmpConfigEtagPath: '/tmp/should-change.etag',
+      remoteConfigURI: 'https://foo.bar/mylimit.config'
+    }, function(err, contents) {
+      assert.notExists(err);
+      assert.exists(contents);
+    });
+  });
+});

--- a/test/config.fetcher.tests.js
+++ b/test/config.fetcher.tests.js
@@ -40,7 +40,7 @@ describe('config file fetcher', function() {
       .get('/mylimit.config')
       .reply(200, remoteConfigFile);
 
-    fs.writeFileSync('/tmp/should-not-change', remoteConfigFile, { encoding: 'utf8' })
+    fs.writeFileSync('/tmp/should-not-change', remoteConfigFile, { encoding: 'utf8' });
     fs.writeFileSync('/tmp/should-not-change.etag', '123', { encoding: 'utf8' });
 
     fetcher.fetchRemoteConfiguration({
@@ -81,7 +81,7 @@ describe('config file fetcher', function() {
       .get('/mylimit.config')
       .reply(200, remoteConfigFile);
 
-    fs.writeFileSync('/tmp/should-change', remoteConfigFile, { encoding: 'utf8' })
+    fs.writeFileSync('/tmp/should-change', remoteConfigFile, { encoding: 'utf8' });
     fs.writeFileSync('/tmp/should-change.etag', '1233', { encoding: 'utf8' });
 
     fetcher.fetchRemoteConfiguration({

--- a/test/fixture/fixture-remote.yml
+++ b/test/fixture/fixture-remote.yml
@@ -1,0 +1,41 @@
+port: 19001
+
+log_level: error
+
+buckets:
+  ip:
+    size: 20
+    per_second: 5
+    override:
+      0.0.0.0:
+        size: 100
+        unlimited: true
+
+      127.0.0.1:
+        size: 1000
+        per_second: 500
+
+      10.0.0.1:
+        size: 1
+        per_hour: 2
+
+      with regexp:
+        size: 1000
+        per_second: 500
+        match: !!js/regexp /^127\./i
+
+      with regexp2:
+        size: 1000
+        per_second: 500
+        until: !!timestamp 2010-11-18
+        match: !!js/regexp /^10\./i
+
+  wrong_password:
+    size: 3
+    override:
+      dudu:
+        match: !!js/regexp /dudu.*/i
+        size: 2
+
+  once per hour:
+    per_hour: 1

--- a/test/server.reload.tests.js
+++ b/test/server.reload.tests.js
@@ -1,0 +1,70 @@
+const LimitdServer = require('..').Server;
+const LimitdClient = require('limitd-client');
+const parser = require('../conf/parser/file');
+
+const assert   = require('chai').assert;
+const rimraf   = require('rimraf');
+const path     = require('path');
+const _        = require('lodash');
+const MockDate = require('mockdate');
+
+var client;
+describe('limitd server config reloading', function () {
+  var db_file = path.join(__dirname, 'dbs', 'server.tests.db');
+
+  try{
+    rimraf.sync(db_file);
+  } catch(err){}
+
+  const db_options = { db: db_file };
+
+  var server;
+
+  before(function (done) {
+    server = new LimitdServer(_.extend(db_options, require('./fixture')));
+
+    server.start(function (err, address) {
+      if (err) return done(err);
+      client = new LimitdClient(`limitd://localhost:${address.port}`);
+      client.once('connect', done);
+    });
+  });
+
+  after(function (done) {
+    server.stop(done);
+  });
+
+  afterEach(function () {
+    MockDate.reset();
+  });
+
+  it('should work with a simple request before reloading', function (done) {
+    var now = 1425920267;
+    MockDate.set(now * 1000);
+    client.take('ip', '211.123.12.12', function (err, response) {
+      if (err) return done(err);
+      assert.ok(response.conformant);
+      assert.equal(response.remaining, 9);
+      done();
+    });
+  });
+
+  it('should work with a simple request after reloading', function (done) {
+    var now = 1425920297;
+    MockDate.set(now * 1000);
+
+    var newConfig = parser.parse(`${__dirname}/fixture/fixture-remote.yml`);
+
+    server._db.close(function() {
+      server._reloadDB({ types: newConfig.buckets });
+      setTimeout(function() {
+        client.take('ip', '211.123.12.12', function (err, response) {
+          if (err) return done(err);
+          assert.ok(response.conformant);
+          assert.equal(response.remaining, 19);
+          done();
+        });
+      }, 1000);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,7 +283,7 @@ cb@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cb/-/cb-0.1.0.tgz#26f7e740f2808facc83cef7b20392e4d881b5203"
 
-chai@~4.1.2:
+chai@^4.1.2, chai@~4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.2.tgz#0f64584ba642f0f2ace2806279f4f06ca23ad73c"
   dependencies:
@@ -402,7 +402,7 @@ debug@2.2.0:
   dependencies:
     ms "0.7.1"
 
-debug@3.1.0:
+debug@3.1.0, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -425,6 +425,10 @@ deep-eql@^3.0.0:
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
   dependencies:
     type-detect "^4.0.0"
+
+deep-equal@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
 deep-extend@~0.4.0:
   version "0.4.2"
@@ -885,7 +889,7 @@ json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -1077,7 +1081,7 @@ lodash@^4.0.0, lodash@^4.14.0, lodash@^4.6.1, lodash@~4.17.5:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
-lodash@^4.17.4:
+lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -1124,7 +1128,7 @@ minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@~0.5.1:
+mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -1196,6 +1200,20 @@ nan@~2.8.0:
 ncp@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+
+nock@^9.2.5:
+  version "9.2.5"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-9.2.5.tgz#c131fc8d3c4723f386be0269739638be84733f2f"
+  dependencies:
+    chai "^4.1.2"
+    debug "^3.1.0"
+    deep-equal "^1.0.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.5"
+    mkdirp "^0.5.0"
+    propagate "^1.0.0"
+    qs "^6.5.1"
+    semver "^5.5.0"
 
 node-abi@^2.2.0:
   version "2.4.0"
@@ -1347,6 +1365,10 @@ progress@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
+propagate@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-1.0.0.tgz#00c2daeedda20e87e3782b344adba1cddd6ad709"
+
 protocol-buffers-schema@^2.0.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-2.2.0.tgz#d29c6cd73fb655978fb6989691180db844119f61"
@@ -1384,6 +1406,10 @@ punycode@1.3.2:
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+
+qs@^6.5.1:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
 qs@~6.4.0:
   version "6.4.0"
@@ -1591,7 +1617,7 @@ sax@>=0.6.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-semver@^5.3.0, semver@^5.4.1:
+semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 


### PR DESCRIPTION
This PR adds support to reloading configuration without requiring a deployment or even a full restart of the daemon.

Every `config.remoteConfigInterval` we try to connect to `config.remoteConfigURI` for `config.remoteConfigTimeout`; if the config retrieved successfully from the remote location, is valid, and is different from the previous version, we apply it and reload the database.

Reloading the database requires restarting the connection to it. We still need to run some performance tests to see the impact on clients (if any).