### PR TITLE
Handles unknown bucket errors that don't require a response

### DIFF
--- a/lib/pipeline/RequestHandler.js
+++ b/lib/pipeline/RequestHandler.js
@@ -35,8 +35,16 @@ class RequestHandler extends Duplex {
       metrics.histogram('limitd.database.took', took, tags);
 
       if (err) {
-        if (err.message.indexOf('undefined bucket type') > -1 && !request.skipResponse) {
-          this._queueResponse(request, { error: { type: 'UNKNOWN_BUCKET_TYPE' } });
+        if (err.message.indexOf('undefined bucket type') > -1) {
+          if (request.skipResponse) {
+            logger.info({
+              log_type: 'unknown_bucket_error',
+              request,
+              err
+            }, 'Error detected in the request pipeline.');
+          } else {
+            this._queueResponse(request, { error: { type: 'UNKNOWN_BUCKET_TYPE' } });
+          }
         } else {
           this.emit('error', err);
         }

--- a/server.js
+++ b/server.js
@@ -110,9 +110,8 @@ LimitdServer.prototype._handler = function (socket) {
   });
 
   request_handler.once('error', (err) => {
-    const critical = err.message.indexOf('undefined bucket type') === -1;
-    logger[critical ? 'error' : 'info'](_.extend(sockets_details, { err }), 'Error detected in the request pipeline.');
-    if (critical) { socket.end(); }
+    logger.error(_.extend(sockets_details, { err }), 'Error detected in the request pipeline.');
+    socket.end();
   });
 
   const encoder = new ResponseEncoder();

--- a/test/server.tests.js
+++ b/test/server.tests.js
@@ -304,6 +304,30 @@ describe('limitd server', function () {
         });
       });
     });
+
+    it('should work after a fire and forget call', function (done) {
+      client.reset('wrong_password', 'dudu2');
+      client.take('wrong_password', 'dudu2', function (err, response) {
+        assert.ok(response.conformant);
+        client.reset('wrong_password', 'dudu2', function (err, response) {
+          if (err) return done(err);
+          assert.equal(response.remaining, 2);
+          done();
+        });
+      });
+    });
+
+    it('should work after a fire and forget call with unknown bucket', function (done) {
+      client.reset('unknown_bucket', 'dudu2');
+      client.take('wrong_password', 'dudu2', function (err, response) {
+        assert.ok(response.conformant);
+        client.reset('wrong_password', 'dudu2', function (err, response) {
+          if (err) return done(err);
+          assert.equal(response.remaining, 2);
+          done();
+        });
+      });
+    });
   });
 
   describe('ping', function () {

--- a/test/wrong_request.tests.js
+++ b/test/wrong_request.tests.js
@@ -48,4 +48,31 @@ describe('wrong requests', function () {
 
   });
 
+  it('should not disconnect the socket on unknown bucket type', function (done) {
+    const socket = new Socket();
+    const Request  = require('limitd-protocol').Request;
+
+    var endHandler = function() {
+      done(new Error('Connection closed by the server'));
+    };
+
+    socket.connect(address.port, address.address)
+      .once('connect', function () {
+        const stream = lps.encode();
+        stream.pipe(socket);
+        stream.write(Request.encode({
+          id: '123',
+          type: 'unknown_bucket',
+          key: 'key',
+          method: 'PUT',
+          skipResponse: true,
+          all: true
+        }));
+        setTimeout(function() {
+          endHandler = done;
+          socket.end();
+        }, 100);
+      }).once('end',function() { endHandler(); } );
+  });
+
 });


### PR DESCRIPTION
Changes the handling of unknown bucket errors to never emit `error`
events. If the error is related to a request that does not need a
response the error is logged directly in the Request Handler.

By not emitting errors we avoid breaking the stream pipe which could
would end in new requests not being passed to the RequestHandler.