### PR TITLE
 [Node 10] Upgrade dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:10
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6
+FROM node:8.16
 
 RUN apt-get update && apt-get install -y apt-transport-https && \
   curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.16
+FROM node:8
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,11 @@
 FROM node:8.16
 
-RUN apt-get update && apt-get install -y apt-transport-https && \
-  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-  apt-get update && apt-get install -y yarn
-
 WORKDIR /app
 
 EXPOSE 9231
 
-ADD package.json yarn.lock /app/
-RUN yarn
+ADD package.json package-lock.json /app/
+RUN npm install
 
 # Bundle app source
 ADD . /app

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ In order to use **limitd** you need to setup the server and consume it from the 
 
 This example assumes that you want to implement rate limiting for an express application.
 
+**For Node v6.x.x, use releases in the v5.x.x stream. For Node v8.x.x / v10.x.x use releases in the v6.x.x stream.**
+
 ### node.js client
 To instantiate the **limitd** client:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,9 +64,9 @@
       "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
     },
     "@types/node": {
-      "version": "10.14.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.3.tgz",
-      "integrity": "sha512-2lhc7S28vo8FwR3Jv3Ifyd77AxEsx+Nl9ajWiac6/eWuvZ84zPK4RE05pfqcn3acIzlZDpQj5F1rIKQZX3ptLQ=="
+      "version": "10.14.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.9.tgz",
+      "integrity": "sha512-NelG/dSahlXYtSoVPErrp06tYFrvzj8XLWmKA+X8x0W//4MqbUyZu++giUG/v0bjAT6/Qxa8IjodrfdACyb0Fg=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -87,11 +87,6 @@
           "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
         }
       }
-    },
-    "after": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
     "ajv": {
       "version": "5.5.2",
@@ -165,6 +160,11 @@
         "lodash": "^4.14.0"
       }
     },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -186,17 +186,16 @@
       }
     },
     "auth0-instrumentation": {
-      "version": "github:auth0/auth0-instrumentation#cb15ee193805bd83449bd475054140c93f06c765",
-      "from": "github:auth0/auth0-instrumentation#v2.19.0",
+      "version": "github:auth0/auth0-instrumentation#a51ec3169e836c25381128a70ce1030f9eeb3b55",
+      "from": "github:auth0/auth0-instrumentation#v2.27.3",
       "requires": {
-        "auth0-common-logging": "github:auth0/auth0-common-logging#f97ff057f2d5804be4f6bc38c9c311e38e1756d7",
-        "aws-kinesis-writable": "4.2.0",
+        "aws-kinesis-writable": "4.2.1",
         "blocked": "^1.2.1",
         "bunyan": "^1.8.1",
-        "datadog-metrics": "^0.3.0",
-        "gc-stats": "1.0.2",
+        "datadog-metrics": "~0.8.1",
+        "gc-stats": "^1.2.1",
         "jaeger-client": "3.12.0",
-        "lightstep-tracer": "github:ja30278/lightstep-tracer-javascript#96ce0bc651ed6164ce92c1be02bbb48190dc3579",
+        "lightstep-tracer": "^0.21.0",
         "lodash.omit": "^4.5.0",
         "lodash.throttle": "^4.1.1",
         "moment": "^2.18.1",
@@ -208,15 +207,31 @@
         "protobufjs": "^6.8.8",
         "raven": "^0.10.0",
         "uuid": "^3.0.1",
-        "v8-profiler-node8": "^5.7.6"
+        "v8-profiler-node8": "^6.0.1"
+      },
+      "dependencies": {
+        "auth0-common-logging": {
+          "version": "github:auth0/auth0-common-logging#bb18d333bbde12b10b151d95c272786414267202",
+          "from": "github:auth0/auth0-common-logging#bb18d333bbde12b10b151d95c272786414267202",
+          "requires": {
+            "lodash": "^4.17.11",
+            "request": "^2.27.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
       }
     },
     "aws-kinesis-writable": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/aws-kinesis-writable/-/aws-kinesis-writable-4.2.0.tgz",
-      "integrity": "sha512-NaMWB7VAJbNA263PhCqtgMY9sbu1UFiHQaWCVUvNZK4dFMofq0AZS25l9kkI9wfuD3LTlP2CGuzlD+J5AxNd2w==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/aws-kinesis-writable/-/aws-kinesis-writable-4.2.1.tgz",
+      "integrity": "sha512-MT4aJM0wRodalhV3yBwZ3APjteZoRB3LMoVUL7V+X7JYDt3JSYLWA7zG2mfWVyq9XcCybZRb5Cbd/rJh/NkFIA==",
       "requires": {
         "aws-sdk": "^2.178.0",
+        "fast-safe-stringify": "^2.0.6",
         "lodash.merge": "^4.6.1",
         "retry": "^0.12.0"
       },
@@ -229,9 +244,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.427.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.427.0.tgz",
-      "integrity": "sha512-NpFNZa7Wt9fQ8hRLt40OD1ii3qnIhUkpXH4fMSjXP2YqGxCYAHYRj2yARN86YJKCMH566+QobTRyPjtgEWmMKA==",
+      "version": "2.473.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.473.0.tgz",
+      "integrity": "sha512-1Qr16lOcz4ANzl/oPQRR+fxchfvUx4PVQhUNnDU3FH9OBfU3Xj+Vh6bGYFbreFQgqIqXUTEuJR5pC44uK70YfA==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -303,11 +318,6 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.1.1.tgz",
       "integrity": "sha1-GkFdmsAUwTJWrx/u2dGj5XF6jPc="
     },
-    "bindings": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
-      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew=="
-    },
     "bl": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
@@ -337,14 +347,6 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
-      }
-    },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "requires": {
-        "inherits": "~2.0.0"
       }
     },
     "blocked": {
@@ -391,31 +393,10 @@
         "isarray": "^1.0.0"
       }
     },
-    "buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      },
-      "dependencies": {
-        "buffer-alloc-unsafe": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-          "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
-        }
-      }
-    },
     "buffer-alloc-unsafe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.0.0.tgz",
       "integrity": "sha1-R0qojzTnvHX6MR0uZFdAnFhGw/4="
-    },
-    "buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
     },
     "bufrw": {
       "version": "1.2.1",
@@ -599,11 +580,11 @@
       }
     },
     "datadog-metrics": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/datadog-metrics/-/datadog-metrics-0.3.0.tgz",
-      "integrity": "sha1-/o/DFdwwyqZaATnnwTISx0c73Y4=",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/datadog-metrics/-/datadog-metrics-0.8.1.tgz",
+      "integrity": "sha512-qTSKnddO6GxTJW9FYpmWjvvift3qfyMurDjwNjJnJhBk76pBdDhC0B5V9V+XwPdn4r42qu48kwXNuHJslXlDOA==",
       "requires": {
-        "debug": "2.2.0",
+        "debug": "3.1.0",
         "dogapi": "1.1.0"
       }
     },
@@ -614,26 +595,18 @@
       "dev": true
     },
     "debug": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "requires": {
-        "ms": "0.7.1"
+        "ms": "2.0.0"
       },
       "dependencies": {
         "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
-      }
-    },
-    "decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-      "requires": {
-        "mimic-response": "^1.0.0"
       }
     },
     "deep-eql": {
@@ -803,14 +776,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
-    "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "requires": {
-        "once": "^1.4.0"
-      }
-    },
     "entities": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
@@ -868,11 +833,6 @@
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
-    "expand-template": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
-      "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg=="
-    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
@@ -898,15 +858,15 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
-    "fast-future": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
-      "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo="
-    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
+      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
     },
     "fast-stats": {
       "version": "0.0.3",
@@ -929,36 +889,18 @@
         "mime-types": "^2.1.12"
       }
     },
-    "fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    "fs-minipass": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+      "requires": {
+        "minipass": "^2.2.1"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      }
-    },
-    "fstream-ignore": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-      "requires": {
-        "fstream": "^1.0.0",
-        "inherits": "2",
-        "minimatch": "^3.0.0"
-      }
     },
     "gauge": {
       "version": "2.7.4",
@@ -976,114 +918,53 @@
       }
     },
     "gc-stats": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/gc-stats/-/gc-stats-1.0.2.tgz",
-      "integrity": "sha512-/mXXARj1tc4Q3nOf/K88bOc1wLWvm0tiWy0EZGWxxR7yLDuM5mZmwrKtYnWIEotKI4o2Sycz3mnszFRIIV/v2w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gc-stats/-/gc-stats-1.4.0.tgz",
+      "integrity": "sha512-4FcCj9e8j8rCjvLkqRpGZBLgTC/xr9XEf5By3x77cDucWWB3pJK6FEwXZCTCbb4z8xdaOoi4owBNrvn3ciDdxA==",
       "requires": {
-        "nan": "^2.6.2",
-        "node-pre-gyp": "^0.6.36"
+        "nan": "^2.13.2",
+        "node-pre-gyp": "^0.13.0"
       },
       "dependencies": {
         "abbrev": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
-          }
         },
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true
         },
         "aproba": {
-          "version": "1.1.2",
+          "version": "1.2.0",
           "bundled": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
           }
         },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true
-        },
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true
         },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "^0.14.3"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "requires": {
-            "inherits": "~2.0.0"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
         "brace-expansion": {
-          "version": "1.1.8",
+          "version": "1.1.11",
           "bundled": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "co": {
-          "version": "4.6.0",
+        "chownr": {
+          "version": "1.1.1",
           "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
         },
         "concat-map": {
           "version": "0.0.1",
@@ -1097,96 +978,35 @@
           "version": "1.0.2",
           "bundled": true
         },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "requires": {
-            "boom": "2.x.x"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
         "debug": {
-          "version": "2.6.8",
+          "version": "4.1.1",
           "bundled": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
         "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
+          "version": "0.6.0",
           "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true
         },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "~0.1.0"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
+        "detect-libc": {
+          "version": "1.0.3",
           "bundled": true
         },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.1.4",
+        "fs-minipass": {
+          "version": "1.2.5",
           "bundled": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "fstream": "^1.0.0",
-            "inherits": "2",
-            "minimatch": "^3.0.0"
-          }
         },
         "gauge": {
           "version": "2.7.4",
@@ -1202,21 +1022,8 @@
             "wide-align": "^1.1.0"
           }
         },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -1227,47 +1034,22 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
-          }
-        },
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true
         },
-        "hawk": {
-          "version": "3.1.3",
+        "iconv-lite": {
+          "version": "0.4.24",
           "bundled": true,
           "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
+        "ignore-walk": {
+          "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -1283,7 +1065,7 @@
           "bundled": true
         },
         "ini": {
-          "version": "1.3.4",
+          "version": "1.3.5",
           "bundled": true
         },
         "is-fullwidth-code-point": {
@@ -1293,68 +1075,9 @@
             "number-is-nan": "^1.0.0"
           }
         },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
         "isarray": {
           "version": "1.0.0",
           "bundled": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "jsonify": "~0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "requires": {
-            "mime-db": "~1.27.0"
-          }
         },
         "minimatch": {
           "version": "3.0.4",
@@ -1367,6 +1090,21 @@
           "version": "0.0.8",
           "bundled": true
         },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
@@ -1375,22 +1113,37 @@
           }
         },
         "ms": {
-          "version": "2.0.0",
+          "version": "2.1.1",
           "bundled": true
         },
-        "node-pre-gyp": {
-          "version": "0.6.36",
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        },
+        "needle": {
+          "version": "2.3.1",
           "bundled": true,
           "requires": {
+            "debug": "^4.1.0",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.13.0",
+          "bundled": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
             "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
             "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "request": "^2.81.0",
+            "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^2.2.1",
-            "tar-pack": "^3.4.0"
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -1401,8 +1154,20 @@
             "osenv": "^0.1.4"
           }
         },
+        "npm-bundled": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "npm-packlist": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
         "npmlog": {
-          "version": "4.1.0",
+          "version": "4.1.2",
           "bundled": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -1413,10 +1178,6 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
           "bundled": true
         },
         "object-assign": {
@@ -1439,7 +1200,7 @@
           "bundled": true
         },
         "osenv": {
-          "version": "0.1.4",
+          "version": "0.1.5",
           "bundled": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -1450,27 +1211,15 @@
           "version": "1.0.1",
           "bundled": true
         },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true
-        },
         "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.4.0",
+          "version": "2.0.0",
           "bundled": true
         },
         "rc": {
-          "version": "1.2.1",
+          "version": "1.2.8",
           "bundled": true,
           "requires": {
-            "deep-extend": "~0.4.0",
+            "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
@@ -1483,59 +1232,39 @@
           }
         },
         "readable-stream": {
-          "version": "2.3.1",
+          "version": "2.3.6",
           "bundled": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
             "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.0",
-            "string_decoder": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
             "util-deprecate": "~1.0.1"
           }
         },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
-          }
-        },
         "rimraf": {
-          "version": "2.6.1",
+          "version": "2.6.3",
           "bundled": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
           "bundled": true
         },
         "semver": {
-          "version": "5.3.0",
+          "version": "5.7.0",
           "bundled": true
         },
         "set-blocking": {
@@ -1545,33 +1274,6 @@
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.1",
-          "bundled": true,
-          "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jsbn": "~0.1.0",
-            "tweetnacl": "~0.14.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
         },
         "string-width": {
           "version": "1.0.2",
@@ -1583,21 +1285,11 @@
           }
         },
         "string_decoder": {
-          "version": "1.0.2",
+          "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "safe-buffer": "~5.0.1"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.0.1",
-              "bundled": true
-            }
+            "safe-buffer": "~5.1.0"
           }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -1611,75 +1303,35 @@
           "bundled": true
         },
         "tar": {
-          "version": "2.2.1",
+          "version": "4.4.8",
           "bundled": true,
           "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.2",
-            "inherits": "2"
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
           }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "requires": {
-            "debug": "^2.2.0",
-            "fstream": "^1.0.10",
-            "fstream-ignore": "^1.0.5",
-            "once": "^1.3.3",
-            "readable-stream": "^2.1.4",
-            "rimraf": "^2.5.1",
-            "tar": "^2.2.1",
-            "uid-number": "^0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "requires": {
-            "punycode": "^1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true
         },
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true
         },
-        "uuid": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.3",
           "bundled": true
         }
       }
@@ -1698,11 +1350,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
-    },
     "glob": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
@@ -1717,14 +1364,9 @@
       }
     },
     "google-protobuf": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.7.1.tgz",
-      "integrity": "sha512-6fvlUey6cNKtWSEn1bt4CT4wc2EID1fVluHS1dOnqIlxyIu3cBid2BvWE8Rwl6wN+hRTgiAKhfyydAGV/weZYQ=="
-    },
-    "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.6.1.tgz",
+      "integrity": "sha512-SJYemeX5GjDLPnadcmCNQePQHCS4Hl5fOcI/JawqDIYFhCmrtYAjcx/oTQx/Wi8UuCuZQhfvftbmPePPAYHFtA=="
     },
     "growl": {
       "version": "1.10.3",
@@ -1757,10 +1399,6 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
-    "hashlru": {
-      "version": "github:jfromaniello/hashlru#2309923e44f53c5f936f37918fdefdf1426fcb17",
-      "from": "github:jfromaniello/hashlru#return_value_on_set"
-    },
     "hashring": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
@@ -1789,9 +1427,9 @@
       "dev": true
     },
     "hex2dec": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/hex2dec/-/hex2dec-1.1.2.tgz",
-      "integrity": "sha512-Yu+q/XWr2fFQ11tHxPq4p4EiNkb2y+lAacJNhAdRXVfRIcDH6gi7htWFnnlIzvqHMHoWeIsfXlNAjZInpAOJDA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hex2dec/-/hex2dec-1.0.1.tgz",
+      "integrity": "sha1-lJuzPx/bvqsg4GQDoA/H1f8oQgc="
     },
     "hoek": {
       "version": "4.2.1",
@@ -1847,10 +1485,26 @@
         "sshpk": "^1.7.0"
       }
     },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
     "ieee754": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+    },
+    "ignore-walk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
     },
     "inflight": {
       "version": "1.0.6",
@@ -1981,23 +1635,10 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
-    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -2114,16 +1755,6 @@
         }
       }
     },
-    "level-ttl": {
-      "version": "github:limitd/level-ttl#ecd1bc8e550ec86a652e130f8e2fe7d6448404ad",
-      "from": "github:limitd/level-ttl#limitd_changes",
-      "requires": {
-        "after": ">=0.8.1 <0.9.0-0",
-        "list-stream": ">=1.0.0 <1.1.0-0",
-        "lock": "~0.1.2",
-        "xtend": ">=4.0.0 <4.1.0-0"
-      }
-    },
     "level-updown": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/level-updown/-/level-updown-1.1.1.tgz",
@@ -2132,27 +1763,6 @@
         "abstract-leveldown": ">=1.0.0 <1.1.0-0",
         "externr": ">=1.0.0 <1.1.0-0",
         "xtend": ">=4.0.0 <4.1.0-0"
-      }
-    },
-    "leveldown": {
-      "version": "github:limitd/leveldown#08d8d8ca5573bfd1716ca2cb8471a09c6e72dce5",
-      "from": "github:limitd/leveldown#noprebuild_options",
-      "requires": {
-        "abstract-leveldown": "~4.0.0",
-        "bindings": "~1.3.0",
-        "fast-future": "~1.0.2",
-        "nan": "~2.10.0",
-        "prebuild-install": "^2.1.0"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
-          "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        }
       }
     },
     "levelup": {
@@ -2185,15 +1795,16 @@
       }
     },
     "lightstep-tracer": {
-      "version": "github:ja30278/lightstep-tracer-javascript#96ce0bc651ed6164ce92c1be02bbb48190dc3579",
-      "from": "github:ja30278/lightstep-tracer-javascript#a0v2.19.0",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/lightstep-tracer/-/lightstep-tracer-0.21.1.tgz",
+      "integrity": "sha512-5rH+ZwvTSgOe9/ZQ+IP8U9iNxfm+zknuaL/Us64FHck9qeAiEGMGWMxzXPiEYXrhsAkS5w0jGKU407tHnPB+PQ==",
       "requires": {
         "async": "1.5.0",
         "eventemitter3": "1.1.1",
-        "google-protobuf": "^3.6.1",
-        "hex2dec": "^1.0.1",
+        "google-protobuf": "3.6.1",
+        "hex2dec": "1.0.1",
         "source-map-support": "0.3.3",
-        "thrift": "0.10.0"
+        "thrift": "0.11.0"
       },
       "dependencies": {
         "async": {
@@ -2214,7 +1825,6 @@
         "hashring": "^3.2.0",
         "length-prefixed-message": "^3.0.3",
         "length-prefixed-stream": "~1.4.0",
-        "limitd-protocol": "github:limitd/protocol#3a3bd729fb5194e900d6de0aeed1a179b20833fe",
         "lodash": "~3.7.0",
         "ms": "^1.0.0",
         "reconnect-net": "^1.1.1",
@@ -2222,11 +1832,6 @@
         "tcp-client-failover": "^1.0.2"
       },
       "dependencies": {
-        "hashlru": {
-          "version": "github:jfromaniello/hashlru#2309923e44f53c5f936f37918fdefdf1426fcb17",
-          "from": "github:jfromaniello/hashlru#2309923e44f53c5f936f37918fdefdf1426fcb17",
-          "dev": true
-        },
         "length-prefixed-stream": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/length-prefixed-stream/-/length-prefixed-stream-1.4.0.tgz",
@@ -2239,10 +1844,9 @@
         },
         "limitd-protocol": {
           "version": "github:limitd/protocol#3a3bd729fb5194e900d6de0aeed1a179b20833fe",
-          "from": "github:limitd/protocol#v2.1.0",
-          "dev": true,
+          "from": "github:limitd/protocol#3a3bd729fb5194e900d6de0aeed1a179b20833fe",
           "requires": {
-            "hashlru": "github:jfromaniello/hashlru#2309923e44f53c5f936f37918fdefdf1426fcb17",
+            "hashlru": "github:jfromaniello/hashlru#return_value_on_set",
             "pbf": "^3.0.5",
             "typedarray-to-buffer": "^3.1.2"
           }
@@ -2271,9 +1875,14 @@
       "version": "github:limitd/protocol#3a3bd729fb5194e900d6de0aeed1a179b20833fe",
       "from": "github:limitd/protocol#v2.1.0",
       "requires": {
-        "hashlru": "github:jfromaniello/hashlru#2309923e44f53c5f936f37918fdefdf1426fcb17",
         "pbf": "^3.0.5",
         "typedarray-to-buffer": "^3.1.2"
+      },
+      "dependencies": {
+        "hashlru": {
+          "version": "github:jfromaniello/hashlru#2309923e44f53c5f936f37918fdefdf1426fcb17",
+          "from": "github:jfromaniello/hashlru#2309923e44f53c5f936f37918fdefdf1426fcb17"
+        }
       }
     },
     "limitdb": {
@@ -2283,59 +1892,47 @@
       "requires": {
         "fast-clone": "^1.4.2",
         "level-spaces": "~1.1.1",
-        "level-ttl": "github:limitd/level-ttl#ecd1bc8e550ec86a652e130f8e2fe7d6448404ad",
-        "leveldown": "github:limitd/leveldown#08d8d8ca5573bfd1716ca2cb8471a09c6e72dce5",
         "levelup": "^2.0.2",
         "lodash": "^4.17.4",
         "lru-cache": "^4.0.2",
         "ms": "^0.7.3"
       },
       "dependencies": {
+        "abstract-leveldown": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
+          "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        },
+        "level-ttl": {
+          "version": "github:limitd/level-ttl#ecd1bc8e550ec86a652e130f8e2fe7d6448404ad",
+          "from": "github:limitd/level-ttl#ecd1bc8e550ec86a652e130f8e2fe7d6448404ad",
+          "requires": {
+            "after": ">=0.8.1 <0.9.0-0",
+            "list-stream": ">=1.0.0 <1.1.0-0",
+            "lock": "~0.1.2",
+            "xtend": ">=4.0.0 <4.1.0-0"
+          }
+        },
+        "leveldown": {
+          "version": "github:limitd/leveldown#08d8d8ca5573bfd1716ca2cb8471a09c6e72dce5",
+          "from": "github:limitd/leveldown#08d8d8ca5573bfd1716ca2cb8471a09c6e72dce5",
+          "requires": {
+            "abstract-leveldown": "~4.0.0",
+            "bindings": "~1.3.0",
+            "fast-future": "~1.0.2",
+            "nan": "~2.10.0",
+            "prebuild-install": "^2.1.0"
+          }
+        },
         "ms": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
           "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
         }
       }
-    },
-    "list-stream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/list-stream/-/list-stream-1.0.1.tgz",
-      "integrity": "sha1-40SSrdzNGhZbAorW15WjbE/ZXSk=",
-      "requires": {
-        "readable-stream": "~2.0.5",
-        "xtend": "~4.0.1"
-      },
-      "dependencies": {
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
-    "lock": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/lock/-/lock-0.1.4.tgz",
-      "integrity": "sha1-/sfervF+fDoKVeHaBCgD4l2RdF0="
     },
     "lodash": {
       "version": "4.17.10",
@@ -2399,11 +1996,6 @@
         "mime-db": "~1.33.0"
       }
     },
-    "mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -2416,6 +2008,30 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "requires": {
+        "minipass": "^2.2.1"
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -2492,9 +2108,9 @@
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mv": {
       "version": "2.1.1",
@@ -2529,12 +2145,29 @@
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
       "optional": true
     },
-    "node-abi": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.8.0.tgz",
-      "integrity": "sha512-1/aa2clS0pue0HjckL62CsbhWWU35HARvBDXcJtYKbYR7LnIutmpxmXbuDMV9kEviD2lP/wACOgWmmwljghHyQ==",
+    "needle": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
       "requires": {
-        "semver": "^5.4.1"
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "sax": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+        }
       }
     },
     "node-int64": {
@@ -2543,166 +2176,26 @@
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
     },
     "node-pre-gyp": {
-      "version": "0.6.39",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
-      "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
+      "integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
       "requires": {
         "detect-libc": "^1.0.2",
-        "hawk": "3.1.3",
         "mkdirp": "^0.5.1",
+        "needle": "^2.2.1",
         "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
         "npmlog": "^4.0.2",
-        "rc": "^1.1.7",
-        "request": "2.81.0",
+        "rc": "^1.2.7",
         "rimraf": "^2.6.1",
         "semver": "^5.3.0",
-        "tar": "^2.2.1",
-        "tar-pack": "^3.4.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
-          }
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "requires": {
-            "boom": "2.x.x"
-          }
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
-          }
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-        },
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
-        },
-        "request": {
-          "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-          "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
-          }
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        }
+        "tar": "^4"
       }
     },
     "node-statsd": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/node-statsd/-/node-statsd-0.1.1.tgz",
       "integrity": "sha1-J6WTSHY9CvegN6wqAx/vPwUQE9M="
-    },
-    "noop-logger": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
     },
     "nopt": {
       "version": "4.0.1",
@@ -2711,6 +2204,20 @@
       "requires": {
         "abbrev": "1",
         "osenv": "^0.1.4"
+      }
+    },
+    "npm-bundled": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+      "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g=="
+    },
+    "npm-packlist": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+      "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1"
       }
     },
     "npmlog": {
@@ -2759,11 +2266,6 @@
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.3.tgz",
       "integrity": "sha1-I+OtAp+mamU5Jq2+V+g0Rp+FUKo="
-    },
-    "options": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -2827,35 +2329,6 @@
       "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
       "dev": true
     },
-    "prebuild-install": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
-      "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
-      "requires": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^1.0.2",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "node-abi": "^2.2.0",
-        "noop-logger": "^0.1.1",
-        "npmlog": "^4.0.1",
-        "os-homedir": "^1.0.1",
-        "pump": "^2.0.1",
-        "rc": "^1.1.6",
-        "simple-get": "^2.7.0",
-        "tar-fs": "^1.13.0",
-        "tunnel-agent": "^0.6.0",
-        "which-pm-runs": "^1.0.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
-      }
-    },
     "precond": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
@@ -2914,24 +2387,15 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
-    "pump": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "q": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz",
-      "integrity": "sha1-EYcq7t7okmgRCxCnGESP+xARKhQ="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
       "version": "6.5.2",
@@ -3086,6 +2550,11 @@
       "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
       "optional": true
     },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
@@ -3116,21 +2585,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-    },
-    "simple-concat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
-    },
-    "simple-get": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
-      "requires": {
-        "decompress-response": "^3.3.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
     },
     "simple-lru-cache": {
       "version": "0.0.2",
@@ -3238,74 +2692,23 @@
       }
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+      "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
       "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.2",
-        "inherits": "2"
-      }
-    },
-    "tar-fs": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
-      "requires": {
-        "chownr": "^1.0.1",
-        "mkdirp": "^0.5.1",
-        "pump": "^1.0.0",
-        "tar-stream": "^1.1.2"
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.5",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
       },
       "dependencies": {
-        "pump": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
-      }
-    },
-    "tar-pack": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
-      "integrity": "sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg==",
-      "requires": {
-        "debug": "^2.2.0",
-        "fstream": "^1.0.10",
-        "fstream-ignore": "^1.0.5",
-        "once": "^1.3.3",
-        "readable-stream": "^2.1.4",
-        "rimraf": "^2.5.1",
-        "tar": "^2.2.1",
-        "uid-number": "^0.0.6"
-      }
-    },
-    "tar-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-      "requires": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.2.0",
-        "end-of-stream": "^1.0.0",
-        "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.1",
-        "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-          "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
-          "requires": {
-            "readable-stream": "^2.3.5",
-            "safe-buffer": "^5.1.1"
-          }
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
     },
@@ -3320,20 +2723,13 @@
       }
     },
     "thrift": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.10.0.tgz",
-      "integrity": "sha1-M5r2WSFnezBWCqUdb3qxuAkck3Y=",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.11.0.tgz",
+      "integrity": "sha1-JWEV5P+Hhx4SU39LUQvStCXhOZA=",
       "requires": {
-        "node-int64": "~0.3.0",
-        "q": "1.0.x",
-        "ws": "~0.4.32"
-      },
-      "dependencies": {
-        "node-int64": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.3.3.tgz",
-          "integrity": "sha1-LW5rLs5d6FiLQ9iNG8QbJs0fqE0="
-        }
+        "node-int64": "^0.4.0",
+        "q": "^1.5.0",
+        "ws": ">= 2.2.3"
       }
     },
     "thriftrw": {
@@ -3345,16 +2741,6 @@
         "error": "7.0.2",
         "long": "^2.4.0"
       }
-    },
-    "tinycolor": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
-      "integrity": "sha1-MgtaUtg6u1l42Bo+iH1K77FaYWQ="
-    },
-    "to-buffer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
     "tough-cookie": {
       "version": "2.3.4",
@@ -3392,11 +2778,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "uid-number": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
-    },
     "url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
@@ -3424,12 +2805,12 @@
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "v8-profiler-node8": {
-      "version": "5.7.7",
-      "resolved": "https://registry.npmjs.org/v8-profiler-node8/-/v8-profiler-node8-5.7.7.tgz",
-      "integrity": "sha512-IJcVXkGCgtPLBtCPP8f3ddtu/EVKcHhwOOG4MnV2b5rWR96hmQEgf94t0VqOZCXKxamjk7vrSQJbCRtOwb9sVw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/v8-profiler-node8/-/v8-profiler-node8-6.0.1.tgz",
+      "integrity": "sha512-DD7L0c/2KeFFQxs20VaFPHq/CSintttW4YB+QJdJ5ZohxOegbsMCvnZKHRHVA9UZfVYqq6ZsLaywe74+3JpZjw==",
       "requires": {
         "nan": "^2.5.1",
-        "node-pre-gyp": "^0.6.34"
+        "node-pre-gyp": "^0.11.0"
       }
     },
     "validator": {
@@ -3458,11 +2839,6 @@
       "integrity": "sha1-4W0dH6+KbllqJGQh/ZCneWPQs5Y=",
       "dev": true
     },
-    "which-pm-runs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
-    },
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
@@ -3477,26 +2853,11 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "0.4.32",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
-      "integrity": "sha1-eHphVEFPPJntg8V3IVOyD+sM7DI=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.0.0.tgz",
+      "integrity": "sha512-cknCal4k0EAOrh1SHHPPWWh4qm93g1IuGGGwBjWkXmCG7LsDtL8w9w+YVfaF+KSVwiHQKDIMsSLBVftKf9d1pg==",
       "requires": {
-        "commander": "~2.1.0",
-        "nan": "~1.0.0",
-        "options": ">=0.0.5",
-        "tinycolor": "0.x"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
-          "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E="
-        },
-        "nan": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz",
-          "integrity": "sha1-riT4hQgY1mL8q1rPfzuVv6oszzg="
-        }
+        "async-limiter": "^1.0.0"
       }
     },
     "xml2js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "limitd",
-  "version": "5.11.0",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -168,7 +168,7 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+      "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -328,7 +328,7 @@
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+          "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE="
         }
       }
     },
@@ -418,14 +418,6 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
-      }
-    },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "requires": {
-        "inherits": "~2.0.0"
       }
     },
     "blocked": {
@@ -697,7 +689,7 @@
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
       "requires": {
         "ms": "2.0.0"
       },
@@ -992,7 +984,7 @@
     "fast-safe-stringify": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
-      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
+      "integrity": "sha1-BLJhBsxWaB9RoETPwNds8ACKwsI="
     },
     "fast-stats": {
       "version": "0.0.3",
@@ -1023,7 +1015,7 @@
     "fs-minipass": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
-      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+      "integrity": "sha1-LFzDDe2BKCv+ig18fBhT3esQLAc=",
       "requires": {
         "minipass": "^2.2.1"
       }
@@ -1032,27 +1024,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "fstream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      }
-    },
-    "fstream-ignore": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-      "requires": {
-        "fstream": "^1.0.0",
-        "inherits": "2",
-        "minimatch": "^3.0.0"
-      }
     },
     "gauge": {
       "version": "2.7.4",
@@ -1520,11 +1491,6 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
-    },
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
@@ -1644,7 +1610,7 @@
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -1657,7 +1623,7 @@
     "ignore-walk": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "integrity": "sha1-qD5i59JyrA47VRqqgoMaGbafgvg=",
       "requires": {
         "minimatch": "^3.0.4"
       }
@@ -1791,23 +1757,10 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
-    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -2211,7 +2164,7 @@
     "minipass": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "integrity": "sha1-ys6+SSAiSX9law8PUeJoKp7S2Eg=",
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -2220,14 +2173,14 @@
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "integrity": "sha1-tLBJ4xS+VF486AIjbWzSLNkcPek="
         }
       }
     },
     "minizlib": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "integrity": "sha1-3SfqYTYkPHyIBoToZyuzpF/ZthQ=",
       "requires": {
         "minipass": "^2.2.1"
       }
@@ -2347,7 +2300,7 @@
     "needle": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
-      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+      "integrity": "sha1-aDPnSXXERGQlkOFadQKIxfk5tXw=",
       "requires": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -2357,7 +2310,7 @@
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -2365,7 +2318,7 @@
         "sax": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+          "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
         }
       }
     },
@@ -2385,7 +2338,7 @@
     "node-pre-gyp": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
-      "integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
+      "integrity": "sha1-2x8zIVJy9pLNOPAyOOPptHxd0FQ=",
       "requires": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -2421,12 +2374,12 @@
     "npm-bundled": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
-      "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g=="
+      "integrity": "sha1-57qarc75YrthJI+RchzZMrP+a90="
     },
     "npm-packlist": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
-      "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+      "integrity": "sha1-GQZM35iNqA6jzuRVM4edkBkrv7w=",
       "requires": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1"
@@ -2798,7 +2751,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
     },
     "sax": {
       "version": "1.2.1",
@@ -2954,7 +2907,7 @@
     "tar": {
       "version": "4.4.10",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
-      "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
+      "integrity": "sha1-lGsoELml4LJhQM94vqawsNaJ66E=",
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -2968,7 +2921,7 @@
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "integrity": "sha1-tLBJ4xS+VF486AIjbWzSLNkcPek="
         }
       }
     },
@@ -2990,46 +2943,6 @@
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
-          }
-        }
-      }
-    },
-    "tar-pack": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
-      "integrity": "sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg==",
-      "requires": {
-        "debug": "^2.2.0",
-        "fstream": "^1.0.10",
-        "fstream-ignore": "^1.0.5",
-        "once": "^1.3.3",
-        "readable-stream": "^2.1.4",
-        "rimraf": "^2.5.1",
-        "tar": "^2.2.1",
-        "uid-number": "^0.0.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "tar": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-          "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
-          "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.12",
-            "inherits": "2"
           }
         }
       }
@@ -3120,11 +3033,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "uid-number": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
-    },
     "url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
@@ -3152,174 +3060,12 @@
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "v8-profiler-node8": {
-      "version": "5.7.8",
-      "resolved": "https://registry.npmjs.org/v8-profiler-node8/-/v8-profiler-node8-5.7.8.tgz",
-      "integrity": "sha512-bO/jDuUfUHREO78T8t81y/3F61LyZyx40FZjCr4lGLMfttjYFEECTUWsZZZMneGjhBhYFCXAFYea8hi+dMxc3w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/v8-profiler-node8/-/v8-profiler-node8-6.0.1.tgz",
+      "integrity": "sha512-DD7L0c/2KeFFQxs20VaFPHq/CSintttW4YB+QJdJ5ZohxOegbsMCvnZKHRHVA9UZfVYqq6ZsLaywe74+3JpZjw==",
       "requires": {
         "nan": "^2.5.1",
-        "node-pre-gyp": "^0.6.34"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
-          }
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "requires": {
-            "boom": "2.x.x"
-          }
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.6.39",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
-          "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "hawk": "3.1.3",
-            "mkdirp": "^0.5.1",
-            "nopt": "^4.0.1",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "request": "2.81.0",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^2.2.1",
-            "tar-pack": "^3.4.0"
-          }
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-        },
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
-        },
-        "request": {
-          "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-          "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
-          }
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
-        "tar": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-          "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
-          "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.12",
-            "inherits": "2"
-          }
-        }
+        "node-pre-gyp": "^0.11.0"
       }
     },
     "validator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "limitd",
-  "version": "6.0.0",
+  "version": "5.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -87,6 +87,11 @@
           "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
         }
       }
+    },
+    "after": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
     "ajv": {
       "version": "5.5.2",
@@ -189,6 +194,7 @@
       "version": "github:auth0/auth0-instrumentation#a51ec3169e836c25381128a70ce1030f9eeb3b55",
       "from": "github:auth0/auth0-instrumentation#v2.27.3",
       "requires": {
+        "auth0-common-logging": "github:auth0/auth0-common-logging#bb18d333bbde12b10b151d95c272786414267202",
         "aws-kinesis-writable": "4.2.1",
         "blocked": "^1.2.1",
         "bunyan": "^1.8.1",
@@ -210,18 +216,78 @@
         "v8-profiler-node8": "^6.0.1"
       },
       "dependencies": {
+        "async": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
+          "integrity": "sha1-J5ZkJyNXOFlWVjP8YnRES+4vjOM="
+        },
         "auth0-common-logging": {
           "version": "github:auth0/auth0-common-logging#bb18d333bbde12b10b151d95c272786414267202",
-          "from": "github:auth0/auth0-common-logging#bb18d333bbde12b10b151d95c272786414267202",
+          "from": "github:auth0/auth0-common-logging#v2.22.0",
           "requires": {
             "lodash": "^4.17.11",
             "request": "^2.27.0"
+          }
+        },
+        "google-protobuf": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.6.1.tgz",
+          "integrity": "sha512-SJYemeX5GjDLPnadcmCNQePQHCS4Hl5fOcI/JawqDIYFhCmrtYAjcx/oTQx/Wi8UuCuZQhfvftbmPePPAYHFtA=="
+        },
+        "hex2dec": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/hex2dec/-/hex2dec-1.0.1.tgz",
+          "integrity": "sha1-lJuzPx/bvqsg4GQDoA/H1f8oQgc="
+        },
+        "lightstep-tracer": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/lightstep-tracer/-/lightstep-tracer-0.21.1.tgz",
+          "integrity": "sha512-5rH+ZwvTSgOe9/ZQ+IP8U9iNxfm+zknuaL/Us64FHck9qeAiEGMGWMxzXPiEYXrhsAkS5w0jGKU407tHnPB+PQ==",
+          "requires": {
+            "async": "1.5.0",
+            "eventemitter3": "1.1.1",
+            "google-protobuf": "3.6.1",
+            "hex2dec": "1.0.1",
+            "source-map-support": "0.3.3",
+            "thrift": "0.11.0"
           }
         },
         "lodash": {
           "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
           "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "q": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+          "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+        },
+        "thrift": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.11.0.tgz",
+          "integrity": "sha1-JWEV5P+Hhx4SU39LUQvStCXhOZA=",
+          "requires": {
+            "node-int64": "^0.4.0",
+            "q": "^1.5.0",
+            "ws": ">= 2.2.3"
+          }
+        },
+        "v8-profiler-node8": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/v8-profiler-node8/-/v8-profiler-node8-6.0.1.tgz",
+          "integrity": "sha512-DD7L0c/2KeFFQxs20VaFPHq/CSintttW4YB+QJdJ5ZohxOegbsMCvnZKHRHVA9UZfVYqq6ZsLaywe74+3JpZjw==",
+          "requires": {
+            "nan": "^2.5.1",
+            "node-pre-gyp": "^0.11.0"
+          }
+        },
+        "ws": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.0.0.tgz",
+          "integrity": "sha512-cknCal4k0EAOrh1SHHPPWWh4qm93g1IuGGGwBjWkXmCG7LsDtL8w9w+YVfaF+KSVwiHQKDIMsSLBVftKf9d1pg==",
+          "requires": {
+            "async-limiter": "^1.0.0"
+          }
         }
       }
     },
@@ -244,9 +310,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.473.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.473.0.tgz",
-      "integrity": "sha512-1Qr16lOcz4ANzl/oPQRR+fxchfvUx4PVQhUNnDU3FH9OBfU3Xj+Vh6bGYFbreFQgqIqXUTEuJR5pC44uK70YfA==",
+      "version": "2.474.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.474.0.tgz",
+      "integrity": "sha512-nyTZNeVRJix1AStgvH5zcacemgXOhrMrhsXHMmvPkvaXBp3Boj+A79/G8KMd3f/zfjgjRPi9VG0I/BNzfsP3HQ==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -318,6 +384,11 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.1.1.tgz",
       "integrity": "sha1-GkFdmsAUwTJWrx/u2dGj5XF6jPc="
     },
+    "bindings": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
+      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew=="
+    },
     "bl": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
@@ -347,6 +418,14 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
+      }
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "requires": {
+        "inherits": "~2.0.0"
       }
     },
     "blocked": {
@@ -393,10 +472,31 @@
         "isarray": "^1.0.0"
       }
     },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      },
+      "dependencies": {
+        "buffer-alloc-unsafe": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+          "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+        }
+      }
+    },
     "buffer-alloc-unsafe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.0.0.tgz",
       "integrity": "sha1-R0qojzTnvHX6MR0uZFdAnFhGw/4="
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
     },
     "bufrw": {
       "version": "1.2.1",
@@ -609,6 +709,14 @@
         }
       }
     },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -776,6 +884,14 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "entities": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
@@ -833,6 +949,11 @@
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
+    "expand-template": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
+      "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg=="
+    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
@@ -857,6 +978,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+    },
+    "fast-future": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
+      "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -889,6 +1015,11 @@
         "mime-types": "^2.1.12"
       }
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "fs-minipass": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
@@ -901,6 +1032,27 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      }
+    },
+    "fstream-ignore": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+      "requires": {
+        "fstream": "^1.0.0",
+        "inherits": "2",
+        "minimatch": "^3.0.0"
+      }
     },
     "gauge": {
       "version": "2.7.4",
@@ -1350,6 +1502,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+    },
     "glob": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
@@ -1363,10 +1520,10 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "google-protobuf": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.6.1.tgz",
-      "integrity": "sha512-SJYemeX5GjDLPnadcmCNQePQHCS4Hl5fOcI/JawqDIYFhCmrtYAjcx/oTQx/Wi8UuCuZQhfvftbmPePPAYHFtA=="
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "growl": {
       "version": "1.10.3",
@@ -1399,6 +1556,10 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
+    "hashlru": {
+      "version": "github:jfromaniello/hashlru#2309923e44f53c5f936f37918fdefdf1426fcb17",
+      "from": "github:jfromaniello/hashlru#return_value_on_set"
+    },
     "hashring": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
@@ -1425,11 +1586,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
-    },
-    "hex2dec": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hex2dec/-/hex2dec-1.0.1.tgz",
-      "integrity": "sha1-lJuzPx/bvqsg4GQDoA/H1f8oQgc="
     },
     "hoek": {
       "version": "4.2.1",
@@ -1635,10 +1791,23 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -1755,6 +1924,16 @@
         }
       }
     },
+    "level-ttl": {
+      "version": "github:limitd/level-ttl#ecd1bc8e550ec86a652e130f8e2fe7d6448404ad",
+      "from": "github:limitd/level-ttl#limitd_changes",
+      "requires": {
+        "after": ">=0.8.1 <0.9.0-0",
+        "list-stream": ">=1.0.0 <1.1.0-0",
+        "lock": "~0.1.2",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      }
+    },
     "level-updown": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/level-updown/-/level-updown-1.1.1.tgz",
@@ -1763,6 +1942,27 @@
         "abstract-leveldown": ">=1.0.0 <1.1.0-0",
         "externr": ">=1.0.0 <1.1.0-0",
         "xtend": ">=4.0.0 <4.1.0-0"
+      }
+    },
+    "leveldown": {
+      "version": "github:limitd/leveldown#08d8d8ca5573bfd1716ca2cb8471a09c6e72dce5",
+      "from": "github:limitd/leveldown#noprebuild_options",
+      "requires": {
+        "abstract-leveldown": "~4.0.0",
+        "bindings": "~1.3.0",
+        "fast-future": "~1.0.2",
+        "nan": "~2.10.0",
+        "prebuild-install": "^2.1.0"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
+          "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        }
       }
     },
     "levelup": {
@@ -1794,26 +1994,6 @@
         }
       }
     },
-    "lightstep-tracer": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/lightstep-tracer/-/lightstep-tracer-0.21.1.tgz",
-      "integrity": "sha512-5rH+ZwvTSgOe9/ZQ+IP8U9iNxfm+zknuaL/Us64FHck9qeAiEGMGWMxzXPiEYXrhsAkS5w0jGKU407tHnPB+PQ==",
-      "requires": {
-        "async": "1.5.0",
-        "eventemitter3": "1.1.1",
-        "google-protobuf": "3.6.1",
-        "hex2dec": "1.0.1",
-        "source-map-support": "0.3.3",
-        "thrift": "0.11.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
-          "integrity": "sha1-J5ZkJyNXOFlWVjP8YnRES+4vjOM="
-        }
-      }
-    },
     "limitd-client": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/limitd-client/-/limitd-client-2.14.0.tgz",
@@ -1825,6 +2005,7 @@
         "hashring": "^3.2.0",
         "length-prefixed-message": "^3.0.3",
         "length-prefixed-stream": "~1.4.0",
+        "limitd-protocol": "github:limitd/protocol#3a3bd729fb5194e900d6de0aeed1a179b20833fe",
         "lodash": "~3.7.0",
         "ms": "^1.0.0",
         "reconnect-net": "^1.1.1",
@@ -1832,6 +2013,11 @@
         "tcp-client-failover": "^1.0.2"
       },
       "dependencies": {
+        "hashlru": {
+          "version": "github:jfromaniello/hashlru#2309923e44f53c5f936f37918fdefdf1426fcb17",
+          "from": "github:jfromaniello/hashlru#2309923e44f53c5f936f37918fdefdf1426fcb17",
+          "dev": true
+        },
         "length-prefixed-stream": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/length-prefixed-stream/-/length-prefixed-stream-1.4.0.tgz",
@@ -1844,9 +2030,10 @@
         },
         "limitd-protocol": {
           "version": "github:limitd/protocol#3a3bd729fb5194e900d6de0aeed1a179b20833fe",
-          "from": "github:limitd/protocol#3a3bd729fb5194e900d6de0aeed1a179b20833fe",
+          "from": "github:limitd/protocol#v2.1.0",
+          "dev": true,
           "requires": {
-            "hashlru": "github:jfromaniello/hashlru#return_value_on_set",
+            "hashlru": "github:jfromaniello/hashlru#2309923e44f53c5f936f37918fdefdf1426fcb17",
             "pbf": "^3.0.5",
             "typedarray-to-buffer": "^3.1.2"
           }
@@ -1875,14 +2062,9 @@
       "version": "github:limitd/protocol#3a3bd729fb5194e900d6de0aeed1a179b20833fe",
       "from": "github:limitd/protocol#v2.1.0",
       "requires": {
+        "hashlru": "github:jfromaniello/hashlru#2309923e44f53c5f936f37918fdefdf1426fcb17",
         "pbf": "^3.0.5",
         "typedarray-to-buffer": "^3.1.2"
-      },
-      "dependencies": {
-        "hashlru": {
-          "version": "github:jfromaniello/hashlru#2309923e44f53c5f936f37918fdefdf1426fcb17",
-          "from": "github:jfromaniello/hashlru#2309923e44f53c5f936f37918fdefdf1426fcb17"
-        }
       }
     },
     "limitdb": {
@@ -1892,47 +2074,59 @@
       "requires": {
         "fast-clone": "^1.4.2",
         "level-spaces": "~1.1.1",
+        "level-ttl": "github:limitd/level-ttl#ecd1bc8e550ec86a652e130f8e2fe7d6448404ad",
+        "leveldown": "github:limitd/leveldown#08d8d8ca5573bfd1716ca2cb8471a09c6e72dce5",
         "levelup": "^2.0.2",
         "lodash": "^4.17.4",
         "lru-cache": "^4.0.2",
         "ms": "^0.7.3"
       },
       "dependencies": {
-        "abstract-leveldown": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
-          "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        },
-        "level-ttl": {
-          "version": "github:limitd/level-ttl#ecd1bc8e550ec86a652e130f8e2fe7d6448404ad",
-          "from": "github:limitd/level-ttl#ecd1bc8e550ec86a652e130f8e2fe7d6448404ad",
-          "requires": {
-            "after": ">=0.8.1 <0.9.0-0",
-            "list-stream": ">=1.0.0 <1.1.0-0",
-            "lock": "~0.1.2",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          }
-        },
-        "leveldown": {
-          "version": "github:limitd/leveldown#08d8d8ca5573bfd1716ca2cb8471a09c6e72dce5",
-          "from": "github:limitd/leveldown#08d8d8ca5573bfd1716ca2cb8471a09c6e72dce5",
-          "requires": {
-            "abstract-leveldown": "~4.0.0",
-            "bindings": "~1.3.0",
-            "fast-future": "~1.0.2",
-            "nan": "~2.10.0",
-            "prebuild-install": "^2.1.0"
-          }
-        },
         "ms": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
           "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
         }
       }
+    },
+    "list-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/list-stream/-/list-stream-1.0.1.tgz",
+      "integrity": "sha1-40SSrdzNGhZbAorW15WjbE/ZXSk=",
+      "requires": {
+        "readable-stream": "~2.0.5",
+        "xtend": "~4.0.1"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "lock": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/lock/-/lock-0.1.4.tgz",
+      "integrity": "sha1-/sfervF+fDoKVeHaBCgD4l2RdF0="
     },
     "lodash": {
       "version": "4.17.10",
@@ -1995,6 +2189,11 @@
       "requires": {
         "mime-db": "~1.33.0"
       }
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -2170,6 +2369,14 @@
         }
       }
     },
+    "node-abi": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.8.0.tgz",
+      "integrity": "sha512-1/aa2clS0pue0HjckL62CsbhWWU35HARvBDXcJtYKbYR7LnIutmpxmXbuDMV9kEviD2lP/wACOgWmmwljghHyQ==",
+      "requires": {
+        "semver": "^5.4.1"
+      }
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -2196,6 +2403,11 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/node-statsd/-/node-statsd-0.1.1.tgz",
       "integrity": "sha1-J6WTSHY9CvegN6wqAx/vPwUQE9M="
+    },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
     },
     "nopt": {
       "version": "4.0.1",
@@ -2329,6 +2541,35 @@
       "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
       "dev": true
     },
+    "prebuild-install": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
+      "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^1.0.2",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "node-abi": "^2.2.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "os-homedir": "^1.0.1",
+        "pump": "^2.0.1",
+        "rc": "^1.1.6",
+        "simple-get": "^2.7.0",
+        "tar-fs": "^1.13.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
     "precond": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
@@ -2387,15 +2628,19 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
+    "pump": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-    },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
       "version": "6.5.2",
@@ -2586,6 +2831,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+    },
+    "simple-get": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+      "requires": {
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "simple-lru-cache": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
@@ -2712,6 +2972,93 @@
         }
       }
     },
+    "tar-fs": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
+      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+      "requires": {
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
+    },
+    "tar-pack": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
+      "integrity": "sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg==",
+      "requires": {
+        "debug": "^2.2.0",
+        "fstream": "^1.0.10",
+        "fstream-ignore": "^1.0.5",
+        "once": "^1.3.3",
+        "readable-stream": "^2.1.4",
+        "rimraf": "^2.5.1",
+        "tar": "^2.2.1",
+        "uid-number": "^0.0.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "tar": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+          "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+          "requires": {
+            "block-stream": "*",
+            "fstream": "^1.0.12",
+            "inherits": "2"
+          }
+        }
+      }
+    },
+    "tar-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "requires": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+          "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
+        }
+      }
+    },
     "tcp-client-failover": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tcp-client-failover/-/tcp-client-failover-1.0.2.tgz",
@@ -2720,16 +3067,6 @@
       "requires": {
         "lodash": "^4.6.1",
         "reconnect-net": "^1.0.0"
-      }
-    },
-    "thrift": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.11.0.tgz",
-      "integrity": "sha1-JWEV5P+Hhx4SU39LUQvStCXhOZA=",
-      "requires": {
-        "node-int64": "^0.4.0",
-        "q": "^1.5.0",
-        "ws": ">= 2.2.3"
       }
     },
     "thriftrw": {
@@ -2741,6 +3078,11 @@
         "error": "7.0.2",
         "long": "^2.4.0"
       }
+    },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
     "tough-cookie": {
       "version": "2.3.4",
@@ -2778,6 +3120,11 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "uid-number": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
+    },
     "url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
@@ -2805,12 +3152,174 @@
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "v8-profiler-node8": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/v8-profiler-node8/-/v8-profiler-node8-6.0.1.tgz",
-      "integrity": "sha512-DD7L0c/2KeFFQxs20VaFPHq/CSintttW4YB+QJdJ5ZohxOegbsMCvnZKHRHVA9UZfVYqq6ZsLaywe74+3JpZjw==",
+      "version": "5.7.8",
+      "resolved": "https://registry.npmjs.org/v8-profiler-node8/-/v8-profiler-node8-5.7.8.tgz",
+      "integrity": "sha512-bO/jDuUfUHREO78T8t81y/3F61LyZyx40FZjCr4lGLMfttjYFEECTUWsZZZMneGjhBhYFCXAFYea8hi+dMxc3w==",
       "requires": {
         "nan": "^2.5.1",
-        "node-pre-gyp": "^0.11.0"
+        "node-pre-gyp": "^0.6.34"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "requires": {
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
+          }
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "requires": {
+            "hoek": "2.x.x"
+          }
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "requires": {
+            "boom": "2.x.x"
+          }
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "requires": {
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "requires": {
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "requires": {
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+          "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "^0.5.1",
+            "nopt": "^4.0.1",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "request": "2.81.0",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^2.2.1",
+            "tar-pack": "^3.4.0"
+          }
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+        },
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+        },
+        "request": {
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "requires": {
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
+          }
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "requires": {
+            "hoek": "2.x.x"
+          }
+        },
+        "tar": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+          "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+          "requires": {
+            "block-stream": "*",
+            "fstream": "^1.0.12",
+            "inherits": "2"
+          }
+        }
       }
     },
     "validator": {
@@ -2839,6 +3348,11 @@
       "integrity": "sha1-4W0dH6+KbllqJGQh/ZCneWPQs5Y=",
       "dev": true
     },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
+    },
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
@@ -2851,14 +3365,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "ws": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.0.0.tgz",
-      "integrity": "sha512-cknCal4k0EAOrh1SHHPPWWh4qm93g1IuGGGwBjWkXmCG7LsDtL8w9w+YVfaF+KSVwiHQKDIMsSLBVftKf9d1pg==",
-      "requires": {
-        "async-limiter": "^1.0.0"
-      }
     },
     "xml2js": {
       "version": "0.4.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "limitd",
-  "version": "6.0.0",
+  "version": "5.11.0",
   "description": "Daemon for rate limiting using tocket buckets.",
   "main": "index.js",
   "repository": {
@@ -35,7 +35,7 @@
     "reconnect-net": "1.1.1",
     "server-destroy": "^1.0.1",
     "typedarray-to-buffer": "^3.1.5",
-    "v8-profiler-node8": "^6.0.1",
+    "v8-profiler-node8": "^5.7.8",
     "z-schema": "^3.19.1",
     "z-schema-errors": "^0.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)",
   "license": "MIT",
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "dependencies": {
     "async": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "async": "^2.6.0",
     "auth0-common-logging": "auth0/auth0-common-logging#v2.18.0",
-    "auth0-instrumentation": "auth0/auth0-instrumentation#v2.19.0",
+    "auth0-instrumentation": "github:auth0/auth0-instrumentation#v2.27.3",
     "cb": "^0.1.0",
     "commander": "~2.15.0",
     "js-yaml": "~3.11.0",
@@ -35,7 +35,7 @@
     "reconnect-net": "1.1.1",
     "server-destroy": "^1.0.1",
     "typedarray-to-buffer": "^3.1.5",
-    "v8-profiler-node8": "^5.7.7",
+    "v8-profiler-node8": "^6.0.1",
     "z-schema": "^3.19.1",
     "z-schema-errors": "^0.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "limitd",
-  "version": "5.11.0",
+  "version": "6.0.0",
   "description": "Daemon for rate limiting using tocket buckets.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "reconnect-net": "1.1.1",
     "server-destroy": "^1.0.1",
     "typedarray-to-buffer": "^3.1.5",
-    "v8-profiler-node8": "^5.7.8",
+    "v8-profiler-node8": "^6.0.1",
     "z-schema": "^3.19.1",
     "z-schema-errors": "^0.2.1"
   },


### PR DESCRIPTION
Upgrade dependencies on auth0-instrumentation and v8-profiler-node8 to support Node 10.

This breaks backwards compatibility with Node 6 but **maintains compatibility with Node 8**.

> Note: I've updated the CI scripts since it appears to be using `yarn` although we're using `package-log.json` and do not have `yarn.lock` 